### PR TITLE
Database/add caching of emails

### DIFF
--- a/include/CommandHandler/include/CommandHandler.h
+++ b/include/CommandHandler/include/CommandHandler.h
@@ -10,6 +10,7 @@
 #include "Base64.h"
 #include "MailDB/PgMailDB.h"
 #include "MailDB/ConnectionPool.h"
+#include "MailDB/PgManager.h"
 #include "MailMessageBuilder.h"
 #include "SocketWrapper.h"
 
@@ -45,7 +46,7 @@ public:
     * @see DataBase::MailDB::include::MailDB::MailException.h
     */
     explicit CommandHandler(boost::asio::ssl::context& ssl_context, 
-                            ISXMailDB::ConnectionPool<pqxx::connection>& connection_pool);
+                            ISXMailDB::PgManager& database_manager);
 
     /**
      * @brief Destructs the CommandHandler object and disconnects from the data base.

--- a/include/CommandHandler/src/CommandHandler.cpp
+++ b/include/CommandHandler/src/CommandHandler.cpp
@@ -16,9 +16,9 @@ namespace ISXCommandHandler
 {
 
 CommandHandler::CommandHandler(boost::asio::ssl::context& ssl_context, 
-                               ISXMailDB::ConnectionPool<pqxx::connection>& connection_pool)
+                               ISXMailDB::PgManager& database_manager)
     : m_ssl_context(ssl_context), 
-      m_data_base(std::make_unique<PgMailDB>("localhost", connection_pool))  
+      m_data_base(std::make_unique<PgMailDB>(database_manager))  
 {
     Logger::LogDebug("Entering CommandHandler constructor");
     Logger::LogTrace("Constructor params: ssl_context");

--- a/include/DataBase/MailDB/CMakeLists.txt
+++ b/include/DataBase/MailDB/CMakeLists.txt
@@ -15,6 +15,9 @@ set(LIBRARY_HEADERS
     ${LIBRARY_HEADERS_DIR}/MailException.h
     ${LIBRARY_HEADERS_DIR}/ConnectionPool.h
     ${LIBRARY_HEADERS_DIR}/ConnectionPoolWrapper.h
+    ${LIBRARY_HEADERS_DIR}/PgEmailsWriter.h
+    ${LIBRARY_HEADERS_DIR}/PgManager.h
+    ${LIBRARY_HEADERS_DIR}/EmailsInstance.h
 )
 
 set(LIBRARY_SOURCE_DIR
@@ -23,6 +26,9 @@ set(LIBRARY_SOURCE_DIR
 set(LIBRARY_SOURCE
     ${LIBRARY_SOURCE_DIR}/PgMailDB.cpp
     ${LIBRARY_SOURCE_DIR}/IMailDB.cpp
+    ${LIBRARY_SOURCE_DIR}/PgEmailsWriter.cpp
+    ${LIBRARY_SOURCE_DIR}/PgManager.cpp
+
 )
 
 project(${PROJECT_NAME})

--- a/include/DataBase/MailDB/include/MailDB/ConnectionPool.h
+++ b/include/DataBase/MailDB/include/MailDB/ConnectionPool.h
@@ -11,12 +11,37 @@
 
 namespace ISXMailDB
 {
-
+/**
+ * @brief A thread-safe connection pool for managing database connections.
+ *
+ * This class provides a pool of reusable connections. It allows acquiring and releasing connections
+ * in a thread-safe manner. It uses a condition variable to manage connection availability and 
+ * a timeout for connection acquisition.
+ *
+ * @tparam ConnectionType The type of the connection (e.g., `pqxx::connection`).
+ */
 template <typename ConnectionType>
 class ConnectionPool {
 public:
+    /**
+     * @brief Type alias for a function that creates a new connection.
+     *
+     * This function takes a connection string and returns a shared pointer to a `ConnectionType`.
+     */
     using ConnCreationFunction = std::function<std::shared_ptr<ConnectionType>(const std::string&)>;
 
+    /**
+     * @brief Constructs a `ConnectionPool` with a specified number of connections.
+     *
+     * Initializes the pool with a specified number of connections. If the number of requested connections
+     * exceeds the maximum allowed, the pool will be initialized with the maximum number.
+     *
+     * @param pool_size Number of connections to create initially.
+     * @param connection_str Connection string to be used by the connection creation function.
+     * @param create_connection Function used to create new connections.
+     *
+     * @throws MailException if the connection creation fails.
+     */
     ConnectionPool(uint16_t pool_size, const std::string& connection_str,
                    ConnCreationFunction create_connection)
         : m_connection_string(connection_str), m_timeout(std::chrono::seconds(20))
@@ -33,10 +58,24 @@ public:
             throw MailException(e.what());
         }
     }
-
+    /**
+     * @brief Deleted copy constructor.
+     */
     ConnectionPool(const ConnectionPool&) = delete;
+    /**
+     * @brief Deleted copy assignment operator.
+     */
     ConnectionPool& operator=(const ConnectionPool&) = delete;
 
+    /**
+     * @brief Acquires a connection from the pool.
+     *
+     * Blocks until a connection becomes available or the timeout expires.
+     *
+     * @return A shared pointer to a `ConnectionType` representing the acquired connection.
+     *
+     * @throws MailException if the timeout expires without acquiring a connection.
+     */
     std::shared_ptr<ConnectionType> Acquire() 
     {
         std::unique_lock<std::mutex> lock(m_pool_mutex);
@@ -52,6 +91,13 @@ public:
         return connection;
     }
 
+    /**
+     * @brief Releases a connection back to the pool.
+     *
+     * Returns the connection to the pool and notifies any waiting threads that a connection is available.
+     *
+     * @param connection A shared pointer to the `ConnectionType` connection to be released.
+     */
     void Release(std::shared_ptr<ConnectionType> connection)
     {
         std::unique_lock<std::mutex> lock(m_pool_mutex);
@@ -61,6 +107,11 @@ public:
         m_cv.notify_one();
     }
 
+    /**
+     * @brief Sets the timeout for acquiring a connection.
+     *
+     * @param timeout The timeout duration to set for acquiring a connection.
+     */
     void set_timeout(std::chrono::seconds timeout) { m_timeout = timeout;}
 
 private:

--- a/include/DataBase/MailDB/include/MailDB/ConnectionPool.h
+++ b/include/DataBase/MailDB/include/MailDB/ConnectionPool.h
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <memory>
 #include <cstdint>
+#include <functional>
 
 #include "MailException.h"
 
@@ -32,6 +33,9 @@ public:
             throw MailException(e.what());
         }
     }
+
+    ConnectionPool(const ConnectionPool&) = delete;
+    ConnectionPool& operator=(const ConnectionPool&) = delete;
 
     std::shared_ptr<ConnectionType> Acquire() 
     {

--- a/include/DataBase/MailDB/include/MailDB/ConnectionPoolWrapper.h
+++ b/include/DataBase/MailDB/include/MailDB/ConnectionPoolWrapper.h
@@ -4,23 +4,55 @@
 
 namespace ISXMailDB
 {
-
+/**
+ * @brief A wrapper class for managing a single connection from the `ConnectionPool`.
+ *
+ * This class provides automatic acquisition and release of a connection from the
+ * `ConnectionPool`. It ensures that the connection is returned to the pool when the
+ * `ConnectionPoolWrapper` object is destroyed.
+ *
+ * @tparam ConnectionType The type of the connection (e.g., `pqxx::connection`).
+ */
 template <typename ConnectionType>
 class ConnectionPoolWrapper {
 public:
+    /**
+     * @brief Constructs a `ConnectionPoolWrapper` by acquiring a connection from the pool.
+     *
+     * @param pool The connection pool from which to acquire the connection.
+     */
     ConnectionPoolWrapper(ConnectionPool<ConnectionType>& pool)
         : m_connection_pool(pool), m_connection(pool.Acquire()) 
     {}
 
+    /**
+     * @brief Destructor that releases the connection back to the pool.
+     */
     ~ConnectionPoolWrapper() 
     {
         m_connection_pool.Release(m_connection);
     }
 
+    ConnectionPoolWrapper(const ConnectionPoolWrapper&) = delete;
+    ConnectionPoolWrapper& operator=(const ConnectionPoolWrapper&) = delete;
+
+    ConnectionPoolWrapper(ConnectionPoolWrapper&&) = delete;
+    ConnectionPoolWrapper& operator=(ConnectionPoolWrapper&&) = delete;
+
+    /**
+     * @brief Dereference operator for accessing the underlying connection.
+     *
+     * @return A reference to the underlying connection.
+     */
     ConnectionType& operator*() {
         return *m_connection;
     }
 
+    /**
+     * @brief Arrow operator for accessing members of the underlying connection.
+     *
+     * @return A pointer to the underlying connection.
+     */
     ConnectionType* operator->() {
         return m_connection.get();
     }

--- a/include/DataBase/MailDB/include/MailDB/EmailsInstance.h
+++ b/include/DataBase/MailDB/include/MailDB/EmailsInstance.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+#include <vector>
+
+namespace ISXMailDB
+{
+
+struct EmailsInstance
+{
+    struct LoggedInUser
+    {
+        uint32_t sender_id;
+        std::string sender_name;
+    } sender;
+    std::vector<std::string> receivers;
+    std::string subject;
+    std::string body;
+};
+
+}

--- a/include/DataBase/MailDB/include/MailDB/IMailDB.h
+++ b/include/DataBase/MailDB/include/MailDB/IMailDB.h
@@ -73,28 +73,22 @@ class IMailDB
 {
 public:
     /**
-     * @brief Constructs an IMailDB object with the given host name.
-     * @param host_name The host name associated with the mail database.
-     * @throw MailException If the host name is empty.
+     * @brief Constructs an IMailDB object.
      */
-    IMailDB(const std::string_view host_name) : m_user_name(), m_user_id(0)
+    IMailDB() : m_user_id(0)
     {
-        if (host_name.empty())
-        {
-            throw MailException("Host name couldn't be empty"); // change
-        }
-        m_host_name = host_name;
     }
+
+    /**
+     * @brief Copy constructor is deletd.
+     */
+    IMailDB(const IMailDB&) = delete;
+
     /**
      * @brief Virtual destructor.
      */
     virtual ~IMailDB() = default;
 
-    /**
-    * @brief Copy constructor.
-    * Constructs an IMailDB object with the other.m_host_name host name.
-    */
-    IMailDB(const IMailDB&);
     /**
      * @brief Deleted copy assignment operator.
      */
@@ -287,9 +281,6 @@ protected:
      * @return True if the password matches the hashed password, otherwise false.
      */
     virtual bool VerifyPassword(const std::string& password, const std::string& hashed_password) = 0;
-
-    std::string m_host_name; ///< The host name associated with the database.
-    uint32_t m_host_id; ///< The host ID associated with the database.
 
     std::string m_user_name; ///< The name of current logged in user.
     uint32_t m_user_id; ///< The ID of current logged in user.

--- a/include/DataBase/MailDB/include/MailDB/IMailDB.h
+++ b/include/DataBase/MailDB/include/MailDB/IMailDB.h
@@ -262,12 +262,6 @@ public:
 
 protected:
     /**
-     * @brief Inserts the host name into the database if does not exist.
-     * @param host_name The host name to insert.
-     */
-    virtual void InsertHost(const std::string_view host_name) = 0;
-
-    /**
      * @brief Hashes a password for secure storage.
      * @param password The password to hash.
      * @return The hashed password.

--- a/include/DataBase/MailDB/include/MailDB/PgEmailsWriter.h
+++ b/include/DataBase/MailDB/include/MailDB/PgEmailsWriter.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <queue>
+#include <pqxx/pqxx>
+#include <thread>
+#include <mutex>
+#include <string>
+#include <chrono>
+#include <memory>
+
+#include "EmailsInstance.h"
+
+namespace ISXMailDB
+{
+
+class PgEmailsWriter
+{
+public:
+    PgEmailsWriter(const std::string& connection_string, 
+                   const uint16_t max_queue_size, const std::chrono::milliseconds& thread_sleep_interval);
+
+    ~PgEmailsWriter();
+
+    PgEmailsWriter(const PgEmailsWriter&) = delete;
+    PgEmailsWriter& operator=(const PgEmailsWriter&) = delete;
+
+    void AddEmails(EmailsInstance&& emails);
+
+
+private:
+    void ProcessQueue();
+
+    void InsertEmail(const EmailsInstance& emails, pqxx::work& work);
+    uint32_t RetriveUserId(const std::string_view user_name, pqxx::transaction_base& ntx);
+    uint32_t InsertEmailBody(const std::string_view content, pqxx::transaction_base& transaction);
+    void PerformEmailInsertion(const uint32_t sender_id, const uint32_t receiver_id,
+                               const std::string_view subject, const uint32_t body_id, 
+                               pqxx::transaction_base& transaction);
+
+    std::queue<EmailsInstance> m_queue;
+    mutable std::mutex m_mtx;
+    std::thread m_worker_thread;
+    bool m_stop_thread;
+    std::unique_ptr<pqxx::connection> m_conn;
+    
+    uint16_t m_max_queue_size;
+    std::chrono::milliseconds m_thread_sleep_interval;
+
+};
+
+}

--- a/include/DataBase/MailDB/include/MailDB/PgEmailsWriter.h
+++ b/include/DataBase/MailDB/include/MailDB/PgEmailsWriter.h
@@ -12,40 +12,115 @@
 
 namespace ISXMailDB
 {
-
+/**
+ * @brief A class for managing and inserting email data into a PostgreSQL database.
+ *
+ * This class handles email data by queuing emails for insertion into a PostgreSQL database. 
+ * It processes the queue in a separate thread and ensures that the email data is correctly
+ * inserted into the database.
+ */
 class PgEmailsWriter
 {
 public:
+/**
+     * @brief Constructs a `PgEmailsWriter` instance.
+     *
+     * Initializes the `PgEmailsWriter` with the connection string, host ID, maximum queue size,
+     * and thread sleep interval. It also starts the worker thread for processing the email queue.
+     *
+     * @param connection_string The connection string for PostgreSQL.
+     * @param host_id The ID of the host in the database.
+     * @param max_queue_size Maximum number of emails that can be held in the queue.
+     * @param thread_sleep_interval Interval at which the worker thread sleeps between processing.
+     */
     PgEmailsWriter(const std::string_view connection_string, uint32_t host_id,
                    const uint16_t max_queue_size, const std::chrono::milliseconds& thread_sleep_interval);
 
+    /**
+     * @brief Destructor that stops the worker thread and cleans up resources.
+     */
     ~PgEmailsWriter();
 
     PgEmailsWriter(const PgEmailsWriter&) = delete;
     PgEmailsWriter& operator=(const PgEmailsWriter&) = delete;
 
+    PgEmailsWriter(PgEmailsWriter&&) = delete;
+    PgEmailsWriter& operator=(PgEmailsWriter&&) = delete;
+
+    /**
+     * @brief Adds emails to the queue for processing.
+     *
+     * Moves the provided `EmailsInstance` object into the queue.
+     *
+     * @param emails The `EmailsInstance` object containing the emails to be added.
+     */
     void AddEmails(EmailsInstance&& emails);
 
 
 private:
+    /**
+     * @brief Processes the email queue in a separate thread.
+     *
+     * This method continuously processes emails from the queue and inserts them into the database.
+     */
     void ProcessQueue();
 
+    /**
+     * @brief Inserts email data into the database.
+     *
+     * Handles the insertion of email data within a transaction.
+     *
+     * @param emails The `EmailsInstance` object containing the emails to be inserted.
+     * @param work The `pqxx::work` transaction object used for database operations.
+     * @return `true` if the insertion was successful, `false` otherwise.
+     */
     bool InsertEmail(const EmailsInstance& emails, pqxx::work& work);
+
+    /**
+     * @brief Retrieves the user ID for a given user name.
+     *
+     * Queries the database to find the user ID for the specified user name.
+     *
+     * @param user_name The user name for which to retrieve the ID.
+     * @param ntx The `pqxx::transaction_base` object used for database operations.
+     * @return The user ID associated with the specified user name.
+     */
     uint32_t RetriveUserId(const std::string_view user_name, pqxx::transaction_base& ntx);
+
+    /**
+     * @brief Inserts an email body into the database.
+     *
+     * Handles the insertion of email body content and returns the ID of the inserted body.
+     *
+     * @param content The content of the email body.
+     * @param transaction The `pqxx::transaction_base` object used for database operations.
+     * @return The ID of the inserted email body.
+     */
     uint32_t InsertEmailBody(const std::string_view content, pqxx::transaction_base& transaction);
+
+    /**
+     * @brief Performs the insertion of an email into the database.
+     *
+     * Completes the email insertion process by adding the sender, receiver, subject, and body ID.
+     *
+     * @param sender_id The ID of the sender.
+     * @param receiver_id The ID of the receiver.
+     * @param subject The subject of the email.
+     * @param body_id The ID of the email body.
+     * @param transaction The `pqxx::transaction_base` object used for database operations.
+     */
     void PerformEmailInsertion(const uint32_t sender_id, const uint32_t receiver_id,
                                const std::string_view subject, const uint32_t body_id, 
                                pqxx::transaction_base& transaction);
 
-    std::queue<EmailsInstance> m_queue;
-    std::mutex m_mtx;
-    std::thread m_worker_thread;
-    bool m_stop_thread;
-    std::unique_ptr<pqxx::connection> m_conn;
-    
-    uint16_t m_max_queue_size;
-    std::chrono::milliseconds m_tread_sleep_interval;
-    const uint32_t HOST_ID;
+    std::queue<EmailsInstance> m_queue;                ///< Queue of email instances to be processed
+    std::mutex m_mtx;                                  ///< Mutex for thread safety
+    std::thread m_worker_thread;                       ///< Worker thread for processing the email queue
+    bool m_stop_thread;                                ///< Flag to stop the worker thread
+    std::unique_ptr<pqxx::connection> m_conn;          ///< Database connection
+    uint16_t m_max_queue_size;                         ///< Maximum size of the email queue
+    std::chrono::milliseconds m_tread_sleep_interval;  ///< Interval at which the worker thread sleeps
+    const uint32_t HOST_ID;                            ///< ID of the host in the database
 };
 
 }

--- a/include/DataBase/MailDB/include/MailDB/PgEmailsWriter.h
+++ b/include/DataBase/MailDB/include/MailDB/PgEmailsWriter.h
@@ -16,7 +16,7 @@ namespace ISXMailDB
 class PgEmailsWriter
 {
 public:
-    PgEmailsWriter(const std::string& connection_string, 
+    PgEmailsWriter(const std::string_view connection_string, uint32_t host_id,
                    const uint16_t max_queue_size, const std::chrono::milliseconds& thread_sleep_interval);
 
     ~PgEmailsWriter();
@@ -30,7 +30,7 @@ public:
 private:
     void ProcessQueue();
 
-    void InsertEmail(const EmailsInstance& emails, pqxx::work& work);
+    bool InsertEmail(const EmailsInstance& emails, pqxx::work& work);
     uint32_t RetriveUserId(const std::string_view user_name, pqxx::transaction_base& ntx);
     uint32_t InsertEmailBody(const std::string_view content, pqxx::transaction_base& transaction);
     void PerformEmailInsertion(const uint32_t sender_id, const uint32_t receiver_id,
@@ -38,14 +38,14 @@ private:
                                pqxx::transaction_base& transaction);
 
     std::queue<EmailsInstance> m_queue;
-    mutable std::mutex m_mtx;
+    std::mutex m_mtx;
     std::thread m_worker_thread;
     bool m_stop_thread;
     std::unique_ptr<pqxx::connection> m_conn;
     
     uint16_t m_max_queue_size;
-    std::chrono::milliseconds m_thread_sleep_interval;
-
+    std::chrono::milliseconds m_tread_sleep_interval;
+    const uint32_t HOST_ID;
 };
 
 }

--- a/include/DataBase/MailDB/include/MailDB/PgMailDB.h
+++ b/include/DataBase/MailDB/include/MailDB/PgMailDB.h
@@ -7,9 +7,13 @@
 #include "IMailDB.h"
 #include "ConnectionPool.h"
 #include "ConnectionPoolWrapper.h"
+#include "PgEmailsWriter.h"
+#include "PgManager.h"
+#include "EmailsInstance.h"
 
 namespace ISXMailDB
 {
+
 /**
  * @class PgMailDB
  * @brief Concrete implementation of the IMailDB interface using PostgreSQL as the database backend.
@@ -22,25 +26,11 @@ class PgMailDB : public IMailDB
 
 public:
     /**
-     * @brief Constructs a PgMailDB instance with the given host name and connection pool.
+     * @brief Constructs a PgMailDB.
      * 
-     * Constructor also inserts host with host_name in database if it doesn't exist 
-     * using InsertHost method
-     * 
-     * @param host_name The name of the host for the database connection.
-     * @param connection_pool reference to the connection pool.
-     * @throw MailException If the host name is empty.
+     * @param manager The class that stores data required for initialization.
      */
-    PgMailDB(const std::string_view host_name, ConnectionPool<pqxx::connection>& connection_pool);
-
-    /**
-     * @brief Copy constructor for PgMailDB.
-     * 
-     * Copies other PgMailDB host_name and refers to same connection pool
-     * 
-     * @param other The PgMailDB instance to copy.
-     */
-    PgMailDB(const PgMailDB&);
+    PgMailDB(PgManager& manager);
 
     /**
      * @brief Destructor for PgMailDB.
@@ -173,8 +163,11 @@ protected:
      */
     void CheckIfUserLoggedIn();
 
+    std::string m_host_name; ///< The host name associated with the database.
+    uint32_t m_host_id; ///< The host ID associated with the database.
 
     ConnectionPool<pqxx::connection>& m_connection_pool; ///< The connection pool of connections to the PostgreSQL database.
+    std::shared_ptr<PgEmailsWriter> m_email_writer; ///< The connection pool of connections to the PostgreSQL database
 };
 
 }

--- a/include/DataBase/MailDB/include/MailDB/PgMailDB.h
+++ b/include/DataBase/MailDB/include/MailDB/PgMailDB.h
@@ -158,8 +158,8 @@ protected:
      */
     void CheckIfUserLoggedIn();
 
-    std::string m_host_name; ///< The host name associated with the database.
-    uint32_t m_host_id; ///< The host ID associated with the database.
+    const std::string HOST_NAME; ///< The host name associated with the database.
+    const uint32_t HOST_ID; ///< The host ID associated with the database.
 
     ConnectionPool<pqxx::connection>& m_connection_pool; ///< The connection pool of connections to the PostgreSQL database.
     std::shared_ptr<PgEmailsWriter> m_email_writer; ///< The connection pool of connections to the PostgreSQL database

--- a/include/DataBase/MailDB/include/MailDB/PgMailDB.h
+++ b/include/DataBase/MailDB/include/MailDB/PgMailDB.h
@@ -161,8 +161,8 @@ protected:
     const std::string HOST_NAME; ///< The host name associated with the database.
     const uint32_t HOST_ID; ///< The host ID associated with the database.
 
-    ConnectionPool<pqxx::connection>& m_connection_pool; ///< The connection pool of connections to the PostgreSQL database.
-    std::shared_ptr<PgEmailsWriter> m_email_writer; ///< The connection pool of connections to the PostgreSQL database
+    std::shared_ptr<ConnectionPool<pqxx::connection>> m_connection_pool; ///< The connection pool of connections to the PostgreSQL database.
+    std::shared_ptr<PgEmailsWriter> m_email_writer; ///< The object that is responsible for caching emails
 };
 
 }

--- a/include/DataBase/MailDB/include/MailDB/PgMailDB.h
+++ b/include/DataBase/MailDB/include/MailDB/PgMailDB.h
@@ -94,11 +94,6 @@ public:
 
 protected:
     /**
-     * @copydoc IMailDB::InsertHost
-     */ 
-    void InsertHost(const std::string_view host_name) override;
-
-    /**
      * @copydoc IMailDB::HashPassword
      */ 
     std::string HashPassword(const std::string& password) override;

--- a/include/DataBase/MailDB/include/MailDB/PgManager.h
+++ b/include/DataBase/MailDB/include/MailDB/PgManager.h
@@ -8,42 +8,127 @@
 namespace ISXMailDB
 {
 
+/**
+ * @brief Manages database connections and email writer functionality.
+ *
+ * The `PgManager` class is responsible for initializing and managing the connection pool
+ * and the email writer. It handles the setup of connections, manages email caching,
+ * and provides access to key components of the database management system.
+ */
 class PgManager
 {
 public:
+    /**
+     * @brief Constructs a `PgManager` instance.
+     *
+     * Initializes the manager with the given connection string, host name, and a flag
+     * indicating whether to cache emails.
+     *
+     * @param connection_string The connection string for PostgreSQL.
+     * @param host_name The name of the host.
+     * @param should_cache_emails Flag indicating whether to cache emails.
+     */
     PgManager(const std::string_view connection_string, const std::string_view host_name, bool should_cache_emails);
 
+    /**
+     * @brief Retrieves the connection pool.
+     *
+     * Provides access to the connection pool used for managing database connections.
+     *
+     * @return A shared pointer to the `ConnectionPool` for PostgreSQL connections.
+     */
     std::shared_ptr<ConnectionPool<pqxx::connection>> get_connection_pool() { return m_connection_pool; }
-    std::shared_ptr<PgEmailsWriter> get_emails_writer () {return m_emails_writer; }
 
+    /**
+     * @brief Retrieves the email writer.
+     *
+     * Provides access to the `PgEmailsWriter` instance used for handling email data.
+     *
+     * @return A shared pointer to the `PgEmailsWriter`.
+     */
+    std::shared_ptr<PgEmailsWriter> get_emails_writer() { return m_emails_writer; }
+
+    /**
+     * @brief Retrieves the host name.
+     *
+     * Provides the name of the host as set during initialization.
+     *
+     * @return The host name.
+     */
     std::string get_host_name() const { return HOST_NAME; }
-    uint32_t get_host_id() const {return m_host_id; }
 
-    uint32_t get_max_writer_queue_size() const { return m_should_cache_emails ? MAX_WRITER_QUEUE_SIZE : 0;}
+    /**
+     * @brief Retrieves the host ID.
+     *
+     * Provides the ID of the host as set during initialization.
+     *
+     * @return The host ID.
+     */
+    uint32_t get_host_id() const { return m_host_id; }
+
+    /**
+     * @brief Retrieves the maximum queue size for the email writer.
+     *
+     * Provides the maximum number of emails that can be held in the writer's queue if caching is enabled.
+     *
+     * @return The maximum writer queue size. Returns 0 if email caching is not enabled.
+     */
+    uint32_t get_max_writer_queue_size() const { return m_should_cache_emails ? MAX_WRITER_QUEUE_SIZE : 0; }
+
+    /**
+     * @brief Retrieves the writer timeout duration.
+     *
+     * Provides the duration for which the email writer will wait before performing its operations.
+     * Returns a zero duration if email caching is not enabled.
+     *
+     * @return The writer timeout duration.
+     */
     std::chrono::milliseconds get_writer_timeout() const 
     { 
         return m_should_cache_emails ? WRITER_TIMEOUT 
             : std::chrono::milliseconds(0);
     }
 
-
 private:
+    /**
+     * @brief Initializes the manager.
+     *
+     * Calls the initialization methods for setting up the connection pool and email writer.
+     */
     void Init();
+
+    /**
+     * @brief Initializes the email writer.
+     *
+     * Sets up the `PgEmailsWriter` instance based on the caching configuration.
+     */
     void InitEmaisWriter();
+
+    /**
+     * @brief Initializes the connection pool.
+     *
+     * Sets up the `ConnectionPool` for PostgreSQL connections.
+     */
     void InitConnectionPool();
+
+    /**
+     * @brief Inserts the host information into the database.
+     *
+     * Adds the host details to the database and retrieves its ID.
+     */
     void InsertHost();
 
-    bool m_should_cache_emails;
-    std::shared_ptr<PgEmailsWriter> m_emails_writer;
-    const uint32_t MAX_WRITER_QUEUE_SIZE = 100;
-    const std::chrono::milliseconds WRITER_TIMEOUT{1000};
+    bool m_should_cache_emails;                              ///< Flag indicating whether to cache emails
+    std::shared_ptr<PgEmailsWriter> m_emails_writer;         ///< Shared pointer to the email writer
+    const uint32_t MAX_WRITER_QUEUE_SIZE = 100;              ///< Maximum size of the email writer queue
+    const std::chrono::milliseconds WRITER_TIMEOUT{1000};    ///< Timeout for the email writer operations
 
-    const std::string CONNECTION_STRING;
-    std::shared_ptr<ConnectionPool<pqxx::connection>> m_connection_pool;
-    const uint16_t POOL_INITIAL_SIZE = 10;
+    const std::string CONNECTION_STRING;                     ///< PostgreSQL connection string
+    std::shared_ptr<ConnectionPool<pqxx::connection>> m_connection_pool; ///< Shared pointer to the connection pool
+    const uint16_t POOL_INITIAL_SIZE = 10;                   ///< Initial size of the connection pool
     
-    const std::string HOST_NAME;
-    uint32_t m_host_id;
+    const std::string HOST_NAME;                             ///< Name of the host
+    uint32_t m_host_id;                                      ///< ID of the host in the database
 };
 
 }

--- a/include/DataBase/MailDB/include/MailDB/PgManager.h
+++ b/include/DataBase/MailDB/include/MailDB/PgManager.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <pqxx/pqxx>
+
+#include "ConnectionPool.h"
+#include "PgEmailsWriter.h"
+
+namespace ISXMailDB
+{
+
+class PgManager
+{
+public:
+    PgManager(const std::string_view connection_string, const std::string_view host_name, bool should_cache_emails);
+
+    ConnectionPool<pqxx::connection>& get_connection_pool() { return *m_connection_pool; }
+    std::shared_ptr<PgEmailsWriter> get_emails_writer () {return m_emails_writer; }
+
+    std::string get_host_name() const { return HOST_NAME; }
+    uint32_t get_host_id() const {return m_host_id; }
+
+private:
+    void Init();
+
+    void InitEmaisWriter();
+    void InitConnectionPool();
+    void InsertHost();
+
+    bool m_should_cache_emails;
+    std::shared_ptr<PgEmailsWriter> m_emails_writer;
+    const uint32_t MAX_WRITER_QUEUE_SIZE = 100;
+    const std::chrono::milliseconds WRITER_TIMEOUT{2000};
+
+    const std::string CONNECTION_STRING;
+    std::unique_ptr<ConnectionPool<pqxx::connection>> m_connection_pool;
+    const uint16_t POOL_INITIAL_SIZE = 10;
+    
+    const std::string HOST_NAME;
+    uint32_t m_host_id;
+};
+
+}

--- a/include/DataBase/MailDB/include/MailDB/PgManager.h
+++ b/include/DataBase/MailDB/include/MailDB/PgManager.h
@@ -13,7 +13,7 @@ class PgManager
 public:
     PgManager(const std::string_view connection_string, const std::string_view host_name, bool should_cache_emails);
 
-    ConnectionPool<pqxx::connection>& get_connection_pool() { return *m_connection_pool; }
+    std::shared_ptr<ConnectionPool<pqxx::connection>> get_connection_pool() { return m_connection_pool; }
     std::shared_ptr<PgEmailsWriter> get_emails_writer () {return m_emails_writer; }
 
     std::string get_host_name() const { return HOST_NAME; }
@@ -39,7 +39,7 @@ private:
     const std::chrono::milliseconds WRITER_TIMEOUT{1000};
 
     const std::string CONNECTION_STRING;
-    std::unique_ptr<ConnectionPool<pqxx::connection>> m_connection_pool;
+    std::shared_ptr<ConnectionPool<pqxx::connection>> m_connection_pool;
     const uint16_t POOL_INITIAL_SIZE = 10;
     
     const std::string HOST_NAME;

--- a/include/DataBase/MailDB/include/MailDB/PgManager.h
+++ b/include/DataBase/MailDB/include/MailDB/PgManager.h
@@ -19,9 +19,16 @@ public:
     std::string get_host_name() const { return HOST_NAME; }
     uint32_t get_host_id() const {return m_host_id; }
 
+    uint32_t get_max_writer_queue_size() const { return m_should_cache_emails ? MAX_WRITER_QUEUE_SIZE : 0;}
+    std::chrono::milliseconds get_writer_timeout() const 
+    { 
+        return m_should_cache_emails ? WRITER_TIMEOUT 
+            : std::chrono::milliseconds(0);
+    }
+
+
 private:
     void Init();
-
     void InitEmaisWriter();
     void InitConnectionPool();
     void InsertHost();
@@ -29,7 +36,7 @@ private:
     bool m_should_cache_emails;
     std::shared_ptr<PgEmailsWriter> m_emails_writer;
     const uint32_t MAX_WRITER_QUEUE_SIZE = 100;
-    const std::chrono::milliseconds WRITER_TIMEOUT{2000};
+    const std::chrono::milliseconds WRITER_TIMEOUT{1000};
 
     const std::string CONNECTION_STRING;
     std::unique_ptr<ConnectionPool<pqxx::connection>> m_connection_pool;

--- a/include/DataBase/MailDB/src/PgEmailsWriter.cpp
+++ b/include/DataBase/MailDB/src/PgEmailsWriter.cpp
@@ -1,0 +1,112 @@
+#include "PgEmailsWriter.h"
+#include "MailException.h"
+
+namespace ISXMailDB
+{
+
+PgEmailsWriter::PgEmailsWriter(const std::string& connection_string,
+                               const uint16_t max_queue_size = 100, 
+                               const std::chrono::milliseconds& thread_sleep_interval = std::chrono::milliseconds(2000)) 
+    : m_max_queue_size(max_queue_size), m_thread_sleep_interval(thread_sleep_interval), 
+    m_stop_thread(false) 
+{
+    m_conn =  std::make_unique<pqxx::connection>(connection_string);
+    m_worker_thread = std::thread(&PgEmailsWriter::ProcessQueue, this);
+}
+
+PgEmailsWriter::~PgEmailsWriter()
+{
+    m_stop_thread = true;
+    m_worker_thread.join();
+}
+
+void PgEmailsWriter::AddEmails(EmailsInstance &&emails)
+{
+    std::lock_guard<std::mutex> lockm(m_mtx);
+    if (m_queue.size() >= m_max_queue_size)
+    {
+        throw MailException("Too many mails in queue");
+    }
+}
+
+void PgEmailsWriter::ProcessQueue()
+{
+    while (true) 
+    {
+        std::this_thread::sleep_for(m_thread_sleep_interval);
+
+        if (m_stop_thread)
+            break;
+
+        std::unique_lock<std::mutex> lock(m_mtx);
+        if (m_queue.empty())
+            continue;
+
+        pqxx::work txn(*m_conn);
+        // while(!m_queue.empty())
+        // {
+
+        // }
+//         // Process queue if not empty
+//         std::vector<std::string> dataBatch;
+//         while (!queue.empty()) {
+//             dataBatch.push_back(queue.front());
+//             queue.pop();
+//         }
+
+//         lock.unlock();
+
+//         if (!dataBatch.empty()) {
+//             writeToDatabase(dataBatch);  // Write all collected data in one batch
+//         }
+// }
+    }
+}
+
+void PgEmailsWriter::InsertEmail(const EmailsInstance &emails, pqxx::work &work)
+{
+    uint32_t sender_id = emails.sender.sender_id, body_id;
+    std::vector<uint32_t> receivers_id;
+
+    try
+    {
+        for (size_t i = 0; i < emails.receivers.size(); i++) 
+        {
+            receivers_id.emplace_back(RetriveUserId(emails.receivers[i], work));
+        }
+        body_id = InsertEmailBody(emails.body, work);
+
+        for (size_t i = 0; i < receivers_id.size(); i++) {
+            PerformEmailInsertion(sender_id, receivers_id[i], emails.subject, body_id, work);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        throw MailException(e.what());
+    }
+}
+
+uint32_t PgEmailsWriter::RetriveUserId(const std::string_view user_name, pqxx::transaction_base &ntx)
+{
+    // try
+    // {
+    //     return ntx.query_value<uint32_t>("SELECT user_id FROM users WHERE user_name = " + ntx.quote(user_name) 
+    //                                      + "  AND host_id = " + ntx.quote(m_host_id));
+    // }
+    // catch (pqxx::unexpected_rows &e)
+    // {
+    //     throw MailException("User doesn't exist");
+    // };
+    return 0;
+}
+
+uint32_t PgEmailsWriter::InsertEmailBody(const std::string_view content, pqxx::transaction_base &transaction)
+{
+    return 0;
+}
+
+void PgEmailsWriter::PerformEmailInsertion(const uint32_t sender_id, const uint32_t receiver_id, const std::string_view subject, const uint32_t body_id, pqxx::transaction_base &transaction)
+{
+
+}
+}

--- a/include/DataBase/MailDB/src/PgMailDB.cpp
+++ b/include/DataBase/MailDB/src/PgMailDB.cpp
@@ -23,7 +23,7 @@ PgMailDB::~PgMailDB()
 
 void PgMailDB::SignUp(const std::string_view user_name, const std::string_view password)
 {
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
     pqxx::work tx(*conn);
     try
     {
@@ -67,7 +67,7 @@ bool PgMailDB::VerifyPassword(const std::string& password, const std::string& ha
 
 void PgMailDB::Login(const std::string_view user_name, const std::string_view password)
 {
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
     pqxx::nontransaction ntx(*conn);
     try
     {
@@ -99,7 +99,7 @@ void PgMailDB::Logout()
 
 std::vector<User> PgMailDB::RetrieveUserInfo(const std::string_view user_name)
     {
-        PgConnection conn(m_connection_pool);
+        PgConnection conn(*m_connection_pool);
 
         pqxx::nontransaction nontransaction(*conn);
         pqxx::result user_query_result;
@@ -139,7 +139,7 @@ std::vector<User> PgMailDB::RetrieveUserInfo(const std::string_view user_name)
 
 std::vector<std::string> PgMailDB::RetrieveEmailContentInfo(const std::string_view content)
 {
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
 
     pqxx::nontransaction nontransaction(*conn);
     pqxx::result content_query_result;
@@ -195,7 +195,7 @@ void PgMailDB::InsertEmail(const std::vector<std::string_view> receivers, const 
         return;
     }
 
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
     uint32_t sender_id, body_id;
     std::vector<uint32_t> receivers_id;
     {
@@ -235,7 +235,7 @@ std::vector<Mail> PgMailDB::RetrieveEmails(bool should_retrieve_all)
 {
     CheckIfUserLoggedIn();
 
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
     pqxx::nontransaction ntx(*conn);
 
     // Retrieves email details for the current user, optionally filtering for unread emails, and orders them by sent time.
@@ -267,7 +267,7 @@ void PgMailDB::MarkEmailsAsReceived()
 {
     CheckIfUserLoggedIn();
 
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
     pqxx::work tx(*conn);
 
     tx.exec_params(
@@ -282,7 +282,7 @@ void PgMailDB::MarkEmailsAsReceived()
 
 bool PgMailDB::UserExists(const std::string_view user_name)
 {
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
     pqxx::nontransaction ntx(*conn);
     try 
     {
@@ -297,7 +297,7 @@ bool PgMailDB::UserExists(const std::string_view user_name)
 
 void PgMailDB::DeleteEmail(const std::string_view user_name)
 {
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
 
     uint32_t user_info;
     {
@@ -329,7 +329,7 @@ void PgMailDB::DeleteEmail(const std::string_view user_name)
 
 void PgMailDB::DeleteUser(const std::string_view user_name, const std::string_view password)
 {
-    PgConnection conn(m_connection_pool);
+    PgConnection conn(*m_connection_pool);
     
     try 
     {

--- a/include/DataBase/MailDB/src/PgMailDB.cpp
+++ b/include/DataBase/MailDB/src/PgMailDB.cpp
@@ -14,7 +14,6 @@ PgMailDB::PgMailDB(PgManager& manager)
       m_host_name(manager.get_host_name()),
       m_host_id(manager.get_host_id())
 {
-    InsertHost(m_host_name);
 }
 
 PgMailDB::~PgMailDB()
@@ -39,24 +38,6 @@ void PgMailDB::SignUp(const std::string_view user_name, const std::string_view p
     catch (const pqxx::unexpected_rows& e)
     {
         throw MailException("User already exists");
-    }
-    tx.commit();
-}
-
-void PgMailDB::InsertHost(const std::string_view host_name)
-{
-    PgConnection conn(m_connection_pool);
-    pqxx::work tx(*conn);
-    try
-    {
-        m_host_id = tx.query_value<uint32_t>("SELECT host_id FROM hosts WHERE host_name = " + tx.quote(m_host_name));
-    }
-    catch (pqxx::unexpected_rows& e)
-    {
-        pqxx::result host_id_result = tx.exec_params(
-            "INSERT INTO hosts (host_name) VALUES ( $1 ) RETURNING host_id", m_host_name);
-
-        m_host_id = host_id_result[0][0].as<uint32_t>();
     }
     tx.commit();
 }

--- a/include/DataBase/MailDB/src/PgManager.cpp
+++ b/include/DataBase/MailDB/src/PgManager.cpp
@@ -45,7 +45,7 @@ void PgManager::InitConnectionPool()
 {
     try
     {
-        m_connection_pool = std::make_unique<ISXMailDB::ConnectionPool<pqxx::connection>>(
+        m_connection_pool = std::make_shared<ISXMailDB::ConnectionPool<pqxx::connection>>(
             POOL_INITIAL_SIZE,
             CONNECTION_STRING,
             [] (const std::string& connection_str)

--- a/include/DataBase/MailDB/src/PgManager.cpp
+++ b/include/DataBase/MailDB/src/PgManager.cpp
@@ -1,0 +1,90 @@
+#include "PgManager.h"
+
+namespace ISXMailDB
+{
+
+PgManager::PgManager(const std::string_view connection_string, const std::string_view host_name,
+                     bool should_cache_emails)
+    : CONNECTION_STRING(connection_string), HOST_NAME(host_name),
+      m_should_cache_emails(should_cache_emails)
+{
+    Init();
+}
+
+void PgManager::Init()
+{
+    InsertHost();
+    InitConnectionPool();
+    InitEmaisWriter();
+}
+
+void PgManager::InitEmaisWriter()
+{
+    try
+    {
+        if (!m_should_cache_emails)
+        {
+            m_emails_writer = nullptr;
+            return;
+        }
+        m_emails_writer = std::make_shared<PgEmailsWriter>(
+            CONNECTION_STRING,
+            MAX_WRITER_QUEUE_SIZE, 
+            WRITER_TIMEOUT
+        );
+    }
+    catch(const std::exception& e)
+    {
+        throw MailException(e.what());
+    }
+    
+}
+
+void PgManager::InitConnectionPool()
+{
+    try
+    {
+        m_connection_pool = std::make_unique<ISXMailDB::ConnectionPool<pqxx::connection>>(
+            POOL_INITIAL_SIZE,
+            CONNECTION_STRING,
+            [] (const std::string& connection_str)
+            { 
+                return std::make_shared<pqxx::connection>(connection_str);
+            }
+        );
+
+    }
+    catch(const std::exception& e)
+    {
+        throw MailException(e.what());
+    }
+}
+
+void PgManager::InsertHost()
+{
+    if (HOST_NAME.empty())
+        throw MailException("Host name can't be empty.");
+    try
+    {
+        pqxx::connection conn{CONNECTION_STRING};
+        pqxx::work tx(conn);
+        try
+        {
+            m_host_id = tx.query_value<uint32_t>("SELECT host_id FROM hosts WHERE host_name = " + tx.quote(HOST_NAME));
+        }
+        catch (pqxx::unexpected_rows& e)
+        {
+            pqxx::result host_id_result = tx.exec_params(
+                "INSERT INTO hosts (host_name) VALUES ( $1 ) RETURNING host_id", HOST_NAME);
+
+            m_host_id = host_id_result[0][0].as<uint32_t>();
+        }
+        tx.commit();
+
+    }
+    catch(const std::exception& e)
+    {
+        throw MailException(e.what());
+    }
+}
+}

--- a/include/DataBase/MailDB/src/PgManager.cpp
+++ b/include/DataBase/MailDB/src/PgManager.cpp
@@ -29,6 +29,7 @@ void PgManager::InitEmaisWriter()
         }
         m_emails_writer = std::make_shared<PgEmailsWriter>(
             CONNECTION_STRING,
+            m_host_id,
             MAX_WRITER_QUEUE_SIZE, 
             WRITER_TIMEOUT
         );

--- a/include/DataBase/MailDB/test/CacheTest.h
+++ b/include/DataBase/MailDB/test/CacheTest.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <thread>
+
+#include "MailDB/PgMailDB.h"
+#include "MailDB/MailException.h"
+#include "MailDB/PgManager.h"
+
+#include "Utils.h"
+
+using namespace ISXMailDB;
+
+const char*  CACHE_CONNECTION_STRING = "dbname=testmaildb user=postgres password=password hostaddr=127.0.0.1 port=5432";
+
+class CacheTest : public testing::Test
+{
+protected:
+  static void SetUpTestSuite() 
+  {
+    if (!s_connection.is_open())
+    {
+      FAIL() << "couldn't establish connection with test db\n";
+    }
+    pqxx::work tx(s_connection);
+
+    ASSERT_NO_FATAL_FAILURE(
+      ExecuteQueryFromFile(tx, DB_TABLE_CREATION_FILE)
+    );
+
+    s_database_manager = std::make_unique<PgManager>(CACHE_CONNECTION_STRING, "testhost", true);
+  }
+
+  static void TearDownTestSuite() 
+  {
+    pqxx::work tx(s_connection);
+
+    tx.exec("DROP TABLE hosts, users, \"emailMessages\", \"mailBodies\"");
+    tx.commit();
+
+    s_connection.close();
+  }
+
+  CacheTest() : pg(*s_database_manager) {}
+  ~CacheTest() = default;
+
+
+  void TearDown() override
+  {
+    pqxx::work tx(s_connection);
+
+    tx.exec("TRUNCATE TABLE \"emailMessages\" RESTART IDENTITY CASCADE;");
+    tx.exec("TRUNCATE TABLE \"mailBodies\" RESTART IDENTITY CASCADE;");
+    tx.exec("TRUNCATE TABLE users RESTART IDENTITY CASCADE;");
+
+    tx.commit();
+  }
+
+  PgMailDB pg;
+  static std::unique_ptr<PgManager> s_database_manager;
+  static pqxx::connection s_connection;  
+};
+
+pqxx::connection CacheTest::s_connection{CACHE_CONNECTION_STRING};
+std::unique_ptr<PgManager> CacheTest::s_database_manager = nullptr;
+
+TEST_F(CacheTest, DefaultTest)
+{
+    pg.SignUp("user1", "pass1");
+    pg.Login("user1", "pass1");
+
+    pg.InsertEmail("user1", "sub1", "body1");
+    pg.InsertEmail("user1", "sub2", "body2");
+
+    std::this_thread::sleep_for(3*s_database_manager->get_writer_timeout());
+
+    auto result = pg.RetrieveEmails();
+    EXPECT_EQ(2, result.size());
+}

--- a/include/DataBase/MailDB/test/ConnPoolPqxxTest.h
+++ b/include/DataBase/MailDB/test/ConnPoolPqxxTest.h
@@ -149,3 +149,11 @@ TEST_F(ConnPoolPqxxTest, AcquireTimeoutTest)
         m_con_pool->Release(conns[i]);
     }
 }
+
+TEST_F(ConnPoolPqxxTest, IncorrectConnectionString)
+{
+    EXPECT_THROW(
+    std::make_shared<ConnectionPool<pqxx::connection>>(3, "incorrect connection string", CreateConnection)
+    , std::exception
+    );
+} 

--- a/include/DataBase/MailDB/test/DatabaseFixture.h
+++ b/include/DataBase/MailDB/test/DatabaseFixture.h
@@ -46,18 +46,14 @@ class DatabaseFixture : public testing::Test
   
     static void SetUpTestCase()
     {
-        s_con_pool = std::make_shared<ConnectionPool<pqxx::connection>>(3, CONNECTION_STRING2, 
-        [] (const std::string& connection_str)
-        { 
-            return std::make_shared<pqxx::connection>(connection_str);
-        }
-  );
-        m_database = std::make_unique<ISXMailDB::PgMailDB>("host", *s_con_pool);
+        s_database_manager = std::make_unique<PgManager>(CONNECTION_STRING2, "host", false);
+        m_database = std::make_unique<ISXMailDB::PgMailDB>(*s_database_manager);
     }
 
   protected:
-      inline static std::unique_ptr<ISXMailDB::PgMailDB> m_database;
-      inline static std::shared_ptr<ConnectionPool<pqxx::connection>> s_con_pool;
+    inline static std::unique_ptr<ISXMailDB::PgMailDB> m_database;
+    inline static std::unique_ptr<PgManager> s_database_manager;
+
 };
 
 

--- a/include/DataBase/MailDB/test/PgMailDBTest.h
+++ b/include/DataBase/MailDB/test/PgMailDBTest.h
@@ -11,29 +11,11 @@
 #include "MailDB/MailException.h"
 #include "MailDB/PgManager.h"
 
+#include "Utils.h"
 
 const char*  CONNECTION_STRING1 = "dbname=testmaildb user=postgres password=password hostaddr=127.0.0.1 port=5432";
 
-const char*  DB_INSERT_DUMMY_DATA_FILE = "../../../../../include/DataBase/MailDB/test/db_insert_dummy_data.txt";
-const char*  DB_TABLE_CREATION_FILE = "../../../../../include/DataBase/MailDB/test/db_table_creation.txt";
-
 using namespace ISXMailDB;
-
-void ExecuteQueryFromFile(pqxx::work& tx, std::string filename)
-{
-   std::ifstream file(filename);
-    if (!file.is_open()) 
-    {
-      FAIL() << "couldn't open a file " << filename << "\n"; 
-    }
-
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    std::string sql_commands = buffer.str();
-
-    tx.exec(sql_commands);
-    tx.commit();
-}
 
 bool operator==(const std::vector<Mail>& lhs, const std::vector<Mail>& rhs)
 {
@@ -50,28 +32,6 @@ bool operator==(const std::vector<Mail>& lhs, const std::vector<Mail>& rhs)
       return false;
   }
   return true;
-}
-
-std::string HashPassword(const std::string& password)
-{
-    std::string hashed_password(crypto_pwhash_STRBYTES, '\0');
-
-    if (crypto_pwhash_str(hashed_password.data(),
-        password.c_str(),
-        password.size(),
-        crypto_pwhash_OPSLIMIT_INTERACTIVE,
-        crypto_pwhash_MEMLIMIT_INTERACTIVE) != 0)
-    {
-        throw MailException("Password hashing failed");
-    }
-
-    return hashed_password;
-}
-
-bool VerifyPassword(const std::string& password, const std::string& hashed_password)
-{
-    return crypto_pwhash_str_verify(hashed_password.c_str(), password.c_str(),
-                                    password.size()) == 0;
 }
 
 class PgMailDBTest : public testing::Test

--- a/include/DataBase/MailDB/test/Utils.h
+++ b/include/DataBase/MailDB/test/Utils.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <pqxx/pqxx>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <gtest/gtest.h>
+
+
+#include "MailDB/PgMailDB.h"
+#include "MailDB/MailException.h"
+
+const char*  DB_INSERT_DUMMY_DATA_FILE = "../../../../../include/DataBase/MailDB/test/db_insert_dummy_data.txt";
+const char*  DB_TABLE_CREATION_FILE = "../../../../../include/DataBase/MailDB/test/db_table_creation.txt";
+
+void ExecuteQueryFromFile(pqxx::work& tx, std::string filename)
+{
+   std::ifstream file(filename);
+    if (!file.is_open()) 
+    {
+      FAIL() << "couldn't open a file " << filename << "\n"; 
+    }
+
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    std::string sql_commands = buffer.str();
+
+    tx.exec(sql_commands);
+    tx.commit();
+}
+
+std::string HashPassword(const std::string& password)
+{
+    std::string hashed_password(crypto_pwhash_STRBYTES, '\0');
+
+    if (crypto_pwhash_str(hashed_password.data(),
+        password.c_str(),
+        password.size(),
+        crypto_pwhash_OPSLIMIT_INTERACTIVE,
+        crypto_pwhash_MEMLIMIT_INTERACTIVE) != 0)
+    {
+        throw ISXMailDB::MailException("Password hashing failed");
+    }
+
+    return hashed_password;
+}
+
+bool VerifyPassword(const std::string& password, const std::string& hashed_password)
+{
+    return crypto_pwhash_str_verify(hashed_password.c_str(), password.c_str(),
+                                    password.size()) == 0;
+}

--- a/include/DataBase/MailDB/test/test.cpp
+++ b/include/DataBase/MailDB/test/test.cpp
@@ -4,6 +4,7 @@
 #include "DatabaseFixture.h"
 #include "PgMailDBTest.h"
 #include "ConnPoolPqxxTest.h"
+#include "CacheTest.h"
 
 #include "MailDB/ConnectionPool.h"
 

--- a/include/Server/include/ServerInitializer.h
+++ b/include/Server/include/ServerInitializer.h
@@ -16,6 +16,7 @@
 #include "ThreadPool.h"
 #include "MailDB/PgMailDB.h"
 #include "MailDB/ConnectionPool.h"
+#include "MailDB/PgManager.h"
 
 using boost::asio::ip::tcp;
 using namespace ISXSignalHandler;
@@ -126,6 +127,13 @@ public:
      */
     [[nodiscard]] ISXMailDB::ConnectionPool<pqxx::connection>& get_connection_pool() const;
 
+    /**
+     * @brief Retrieves the manager of database.
+     *
+     * @return The PgManager.
+     */
+    [[nodiscard]] ISXMailDB::PgManager& get_database_manager() const;
+
 private:
     /**
      * @brief Initializes the logging system.
@@ -146,7 +154,7 @@ private:
      * @brief Initializes the connection pool to database.
      *
      */
-    void InitializeConnectionPool();
+    void InitializeDatabaseManager();
 
     /**
      * @brief Initializes the network acceptor.
@@ -180,9 +188,12 @@ private:
     std::chrono::seconds m_timeout_seconds; ///< The timeout duration for communication in seconds.
     uint8_t m_log_level; ///< The log level for the logging system.
 
+
+    std::unique_ptr<ISXMailDB::PgManager> m_database_manager; ///< Unique pointer to the database manager.
+
     std::unique_ptr<ISXMailDB::ConnectionPool<pqxx::connection>> m_connection_pool; ///< Unique pointer to the connection pool.
     const uint16_t POOL_INITIAL_SIZE = 10;  ///< Initial size of the connection pool
-    std::string m_connection_string =
+    const std::string CONNECTION_STRING =
         "postgresql://postgres.qotrdwfvknwbfrompcji:"
         "yUf73LWenSqd9Lt4@aws-0-eu-central-1.pooler."
         "supabase.com:6543/postgres?sslmode=require"; ;  ///< Data base connection string.

--- a/include/Server/src/Server.cpp
+++ b/include/Server/src/Server.cpp
@@ -67,7 +67,7 @@ void SmtpServer::HandleClient(SocketWrapper socket_wrapper)
 
     try
     {
-        CommandHandler command_handler(m_initializer.get_ssl_context(), m_initializer.get_connection_pool());
+        CommandHandler command_handler(m_initializer.get_ssl_context(), m_initializer.get_database_manager());
         MailMessageBuilder mail_builder;
         std::string current_line;
 

--- a/include/Server/src/ServerInitializer.cpp
+++ b/include/Server/src/ServerInitializer.cpp
@@ -98,7 +98,7 @@ void ServerInitializer::InitializeDatabaseManager()
         m_database_manager = std::make_unique<ISXMailDB::PgManager>(
             CONNECTION_STRING,
             "localhost",
-            false
+            true
         );
     }
     catch(const std::exception& e)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,8 @@ int main() {
 
          // Load server certificates and private key
         #ifdef _WIN32
-        ssl_context.use_certificate_chain_file("server.crt");    // public key
-        ssl_context.use_private_key_file("server.key", boost::asio::ssl::context::pem);
+        ssl_context.use_certificate_chain_file("../server.crt");    // public key
+        ssl_context.use_private_key_file("../server.key", boost::asio::ssl::context::pem);
         #else
         ssl_context.use_certificate_chain_file("/etc/ssl/certs/smtp-server/server.crt");    // public key
         ssl_context.use_private_key_file("/etc/ssl/private/server.key", boost::asio::ssl::context::pem);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,8 @@ int main() {
 
          // Load server certificates and private key
         #ifdef _WIN32
-        ssl_context.use_certificate_chain_file("../server.crt");    // public key
-        ssl_context.use_private_key_file("../server.key", boost::asio::ssl::context::pem);
+        ssl_context.use_certificate_chain_file("server.crt");    // public key
+        ssl_context.use_private_key_file("server.key", boost::asio::ssl::context::pem);
         #else
         ssl_context.use_certificate_chain_file("/etc/ssl/certs/smtp-server/server.crt");    // public key
         ssl_context.use_private_key_file("/etc/ssl/private/server.key", boost::asio::ssl::context::pem);


### PR DESCRIPTION
This pull request includes an update to the database. It includes adding caching and a small refactoring of tests. Key changes include:

1.  **Class PgEmailsWriter** - it is responsible for caching emails. To be more precise, it has two main components: a queue and a worker_thread. Other threads can safely add EmailsInstances to the queue, while worker thread writes this instances to database as single transaction once in certain time period.
2. **Class PgManager** - helper class that does some preparations in order to PgMailDB could work. It initializes ConnectionPool for PostgreSQL and PgEmailsWriter. It also inserts host in database if it doens't exist.
3. **Reworked PgMailDB and tests** to handle with PgManager.
4. **Updated server implementation** to handle with PgManager: replaced intialization of ConnectionPool with initialization of PgManger.

